### PR TITLE
Expose thunk features

### DIFF
--- a/src/Halogen/VDom/Thunk.purs
+++ b/src/Halogen/VDom/Thunk.purs
@@ -7,6 +7,7 @@ module Halogen.VDom.Thunk
   , thunk1
   , thunk2
   , thunk3
+  , unsafeEqThunk
   ) where
 
 import Prelude

--- a/src/Halogen/VDom/Thunk.purs
+++ b/src/Halogen/VDom/Thunk.purs
@@ -1,5 +1,7 @@
 module Halogen.VDom.Thunk
   ( Thunk(..)
+  , ThunkArg
+  , ThunkId
   , buildThunk
   , runThunk
   , hoist
@@ -8,6 +10,7 @@ module Halogen.VDom.Thunk
   , thunk2
   , thunk3
   , unsafeEqThunk
+  , unsafeThunkId
   ) where
 
 import Prelude

--- a/src/Halogen/VDom/Thunk.purs
+++ b/src/Halogen/VDom/Thunk.purs
@@ -1,5 +1,5 @@
 module Halogen.VDom.Thunk
-  ( Thunk
+  ( Thunk(..)
   , buildThunk
   , runThunk
   , hoist


### PR DESCRIPTION
This exposes the `Thunk` constructor and the function `unsafeEqThunk`, which is needed for implementing a working `buildWidget` function in presto-dom.